### PR TITLE
Fixed problem when PCAN dongle not plugged in

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -24,7 +24,7 @@
             </Menu.ItemContainerStyle>
             <MenuItem Header="File" x:Name="FileMenu">
                 <MenuItem Header="Open" Click="OpenMenuItem_ClickAsync" />
-                <MenuItem x:Name="RecordMenuItem" Header="Record" Click="RecordMenuItem_ClickAsync" />
+                <MenuItem x:Name="RecordMenuItem" Header="PCAN Capture" Click="RecordMenuItem_ClickAsync" />
                 <Separator x:Name="RecentFilesSeparator" Visibility="Collapsed" />
             </MenuItem>
             <MenuItem Header="Statistics">
@@ -166,7 +166,7 @@
                 </DataGrid.Columns>
             </DataGrid>
             <GridSplitter Grid.Column="1"
-                            Width="3"
+                            Width="Auto"
                             HorizontalAlignment="Stretch"
                             VerticalAlignment="Stretch"
                             Background="LightGray"

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -17,8 +17,7 @@ namespace NMEA2000Analyzer
         private List<Nmea2000Record>? _Data;
         private List<Nmea2000Record>? _assembledData;
         private List<Nmea2000Record>? _filteredData;
-        private bool _isRecording = false;
-
+        
         public MainWindow()
         {
             InitializeComponent();
@@ -211,18 +210,18 @@ namespace NMEA2000Analyzer
 
         private async void RecordMenuItem_ClickAsync(object sender, RoutedEventArgs e)
         {
-            if (!_isRecording)
+            if (PCAN.StartCapture())
             {
-                PCAN.InitCan(true);
-                RecordMenuItem.Header = "Stop recording";
-                _isRecording = true;
-            }
-            else
-            {
-                PCAN.InitCan(false);
-                RecordMenuItem.Header = "Record";
-                _isRecording = false;
+                // Pause here to allow packet to capture.
+                System.Windows.MessageBox.Show(
+                                "Capture Started.  Press OK to stop",
+                                "Capturing Data...",
+                                MessageBoxButton.OK,
+                                MessageBoxImage.Information
+                                );
 
+                PCAN.StopCapture();
+                
                 _Data = PCAN.LoadCapture();
                 UpdateTimestampRange();
 
@@ -233,7 +232,15 @@ namespace NMEA2000Analyzer
                 UpdateSrcDevices(_assembledData);
 
             }
-
+            else 
+            {
+                System.Windows.MessageBox.Show(
+                                "PCAN dongle not plugged in or driver not installed",
+                                "Error:",
+                                MessageBoxButton.OK,
+                                MessageBoxImage.Error
+                                );
+            }
 
         }
 

--- a/PCAN.cs
+++ b/PCAN.cs
@@ -17,21 +17,36 @@ namespace NMEA2000Analyzer
         private static readonly Worker _worker = new Worker(PcanChannel.Usb01, Bitrate.Pcan250);
         private static List<Nmea2000Record>? capture;
         
-        public static void InitCan(Boolean start)
+        public static bool StartCapture()
         {
-            if ((start))
+            try
             {
                 if (capture == null)
-                { 
+                {
                     capture = new List<Nmea2000Record>();
                 }
                 _worker.MessageAvailable += OnMessageAvailable;
                 _worker.Start();
                 Debug.WriteLine("Worker started successfully.");
+                return (true);
             }
-            else
+            catch (PcanBasicException)
+            {
+                return (false);
+            }
+            catch (DllNotFoundException)
+            {
+                return (false);
+            }
+        }
+        public static void StopCapture()
+        {
+            try
             {
                 _worker.Stop();
+            }
+            catch (PcanBasicException e)
+            {
             }
         }
 


### PR DESCRIPTION
This fixed a problem when the PCAN when the PCAN dongle is not plugged in or the driver is not installed.

Also added pop-up boxes to indicate what was happening while capturing CAN packets.

This fixes issue #7.