### PR TITLE
Add Save As for captured packets

### DIFF
--- a/FileFormats.cs
+++ b/FileFormats.cs
@@ -100,6 +100,46 @@ namespace NMEA2000Analyzer
             return FileFormat.Unknown; // Default to unknown format
         }
 
+        public static void SaveCanDump(string filePath, IEnumerable<Nmea2000Record> records)
+        {
+            using var writer = new StreamWriter(filePath, false, Encoding.UTF8);
+
+            foreach (var record in records)
+            {
+                writer.WriteLine(ToCanDumpLine(record));
+            }
+        }
+
+        private static string ToCanDumpLine(Nmea2000Record record)
+        {
+            int priority = int.TryParse(record.Priority, out var parsedPriority) ? parsedPriority : 0;
+            int source = int.TryParse(record.Source, out var parsedSource) ? parsedSource : 0;
+            int destination = int.TryParse(record.Destination, out var parsedDestination) ? parsedDestination : 255;
+            int pgn = int.TryParse(record.PGN, out var parsedPgn) ? parsedPgn : 0;
+
+            int encodedPgn = pgn;
+            if ((pgn & 0xFF00) == 0xEF00 && destination != 255)
+            {
+                encodedPgn = (pgn & 0x1FF00) | (destination & 0xFF);
+            }
+
+            uint canId = ((uint)(priority & 0x7) << 26)
+                       | ((uint)(encodedPgn & 0x1FFFF) << 8)
+                       | (uint)(source & 0xFF);
+
+            string data = record.Data ?? string.Empty;
+            var dataHex = Regex.Matches(data, @"(?:0x)?([0-9A-Fa-f]{2})")
+                               .Select(m => m.Groups[1].Value.ToUpperInvariant());
+
+            string timestampText = "0.000000";
+            if (!string.IsNullOrWhiteSpace(record.Timestamp))
+            {
+                timestampText = record.Timestamp;
+            }
+
+            return $"({timestampText}) can0 {canId:X8}#{string.Concat(dataHex)}";
+        }
+
         public static List<Nmea2000Record> LoadTwoCanCsv(string filePath)
         {
             var records = new List<Nmea2000Record>();

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -24,8 +24,8 @@
             </Menu.ItemContainerStyle>
             <MenuItem Header="File" x:Name="FileMenu">
                 <MenuItem Header="Open" Click="OpenMenuItem_ClickAsync" />
+                <MenuItem Header="Save As" Click="SaveAsMenuItem_Click" />
                 <MenuItem x:Name="RecordMenuItem" Header="PCAN Capture" Click="RecordMenuItem_ClickAsync" />
-                <MenuItem x:Name="RecordToFileMenuItem" Header="PCAN Capture to File" Click="RecordToFileMenuItem_ClickAsync" />
                 <Separator x:Name="RecentFilesSeparator" Visibility="Collapsed" />
             </MenuItem>
             <MenuItem Header="Statistics">

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -25,6 +25,7 @@
             <MenuItem Header="File" x:Name="FileMenu">
                 <MenuItem Header="Open" Click="OpenMenuItem_ClickAsync" />
                 <MenuItem x:Name="RecordMenuItem" Header="PCAN Capture" Click="RecordMenuItem_ClickAsync" />
+                <MenuItem x:Name="RecordToFileMenuItem" Header="PCAN Capture to File" Click="RecordToFileMenuItem_ClickAsync" />
                 <Separator x:Name="RecentFilesSeparator" Visibility="Collapsed" />
             </MenuItem>
             <MenuItem Header="Statistics">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -208,40 +208,46 @@ namespace NMEA2000Analyzer
             }
         }
 
-        private void RecordMenuItem_ClickAsync(object sender, RoutedEventArgs e)
+        private void SaveAsMenuItem_Click(object sender, RoutedEventArgs e)
         {
-            StartLiveCapture();
-        }
+            if (_Data == null || _Data.Count == 0)
+            {
+                MessageBox.Show("No packets are loaded to save.", "Save As",
+                                MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
 
-        private void RecordToFileMenuItem_ClickAsync(object sender, RoutedEventArgs e)
-        {
             var saveFileDialog = new SaveFileDialog
             {
                 Filter = "CanDump log (*.log)|*.log|Text files (*.txt)|*.txt|All Files (*.*)|*.*",
                 DefaultExt = ".log",
                 AddExtension = true,
-                FileName = $"nmea2000-capture-{DateTime.Now:yyyyMMdd-HHmmss}.log",
-                Title = "Save live capture"
+                FileName = $"nmea2000-export-{DateTime.Now:yyyyMMdd-HHmmss}.log",
+                Title = "Save packets as"
             };
 
-            if (saveFileDialog.ShowDialog() == true)
+            if (saveFileDialog.ShowDialog() != true)
+                return;
+
+            try
             {
-                StartLiveCapture(saveFileDialog.FileName);
+                FileFormats.SaveCanDump(saveFileDialog.FileName, _Data);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to save file: {ex.Message}", "Error",
+                                MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 
-        private void StartLiveCapture(string? captureFilePath = null)
+        private void RecordMenuItem_ClickAsync(object sender, RoutedEventArgs e)
         {
-            if (PCAN.StartCapture(captureFilePath))
+            if (PCAN.StartCapture())
             {
                 ClearData();
 
-                var captureMessage = captureFilePath == null
-                    ? "Capture started. Press OK to stop."
-                    : $"Capture started and is being saved to:\n{captureFilePath}\n\nPress OK to stop.";
-
                 System.Windows.MessageBox.Show(
-                                captureMessage,
+                                "Capture started. Press OK to stop.",
                                 "Capturing Data...",
                                 MessageBoxButton.OK,
                                 MessageBoxImage.Information
@@ -262,9 +268,7 @@ namespace NMEA2000Analyzer
             else 
             {
                 System.Windows.MessageBox.Show(
-                                captureFilePath == null
-                                    ? "PCAN dongle not plugged in, driver not installed, or capture file could not be opened"
-                                    : "PCAN dongle not plugged in, driver not installed, or capture file could not be opened for writing",
+                                "PCAN dongle not plugged in or driver not installed",
                                 "Error:",
                                 MessageBoxButton.OK,
                                 MessageBoxImage.Error

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -208,15 +208,40 @@ namespace NMEA2000Analyzer
             }
         }
 
-        private async void RecordMenuItem_ClickAsync(object sender, RoutedEventArgs e)
+        private void RecordMenuItem_ClickAsync(object sender, RoutedEventArgs e)
         {
-            if (PCAN.StartCapture())
+            StartLiveCapture();
+        }
+
+        private void RecordToFileMenuItem_ClickAsync(object sender, RoutedEventArgs e)
+        {
+            var saveFileDialog = new SaveFileDialog
+            {
+                Filter = "CanDump log (*.log)|*.log|Text files (*.txt)|*.txt|All Files (*.*)|*.*",
+                DefaultExt = ".log",
+                AddExtension = true,
+                FileName = $"nmea2000-capture-{DateTime.Now:yyyyMMdd-HHmmss}.log",
+                Title = "Save live capture"
+            };
+
+            if (saveFileDialog.ShowDialog() == true)
+            {
+                StartLiveCapture(saveFileDialog.FileName);
+            }
+        }
+
+        private void StartLiveCapture(string? captureFilePath = null)
+        {
+            if (PCAN.StartCapture(captureFilePath))
             {
                 ClearData();
 
-                // Pause here to allow packet to capture.
+                var captureMessage = captureFilePath == null
+                    ? "Capture started. Press OK to stop."
+                    : $"Capture started and is being saved to:\n{captureFilePath}\n\nPress OK to stop.";
+
                 System.Windows.MessageBox.Show(
-                                "Capture Started.  Press OK to stop",
+                                captureMessage,
                                 "Capturing Data...",
                                 MessageBoxButton.OK,
                                 MessageBoxImage.Information
@@ -237,7 +262,9 @@ namespace NMEA2000Analyzer
             else 
             {
                 System.Windows.MessageBox.Show(
-                                "PCAN dongle not plugged in or driver not installed",
+                                captureFilePath == null
+                                    ? "PCAN dongle not plugged in, driver not installed, or capture file could not be opened"
+                                    : "PCAN dongle not plugged in, driver not installed, or capture file could not be opened for writing",
                                 "Error:",
                                 MessageBoxButton.OK,
                                 MessageBoxImage.Error

--- a/PCAN.cs
+++ b/PCAN.cs
@@ -2,10 +2,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
+using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using System.Windows;
 using static NMEA2000Analyzer.MainWindow;
@@ -15,16 +15,34 @@ namespace NMEA2000Analyzer
     class PCAN
     {
         private static readonly Worker _worker = new Worker(PcanChannel.Usb01, Bitrate.Pcan250);
+        private static readonly object _captureLock = new object();
         private static List<Nmea2000Record>? capture;
+        private static StreamWriter? _captureWriter;
         
-        public static bool StartCapture()
+        public static bool StartCapture(string? captureFilePath = null)
         {
             try
             {
-                if (capture == null)
+                capture = new List<Nmea2000Record>();
+
+                _captureWriter?.Dispose();
+                _captureWriter = null;
+
+                if (!string.IsNullOrWhiteSpace(captureFilePath))
                 {
-                    capture = new List<Nmea2000Record>();
+                    var directory = Path.GetDirectoryName(captureFilePath);
+                    if (!string.IsNullOrWhiteSpace(directory))
+                    {
+                        Directory.CreateDirectory(directory);
+                    }
+
+                    _captureWriter = new StreamWriter(captureFilePath, append: false, Encoding.UTF8)
+                    {
+                        AutoFlush = true
+                    };
                 }
+
+                _worker.MessageAvailable -= OnMessageAvailable;
                 _worker.MessageAvailable += OnMessageAvailable;
                 _worker.Start();
                 Debug.WriteLine("Worker started successfully.");
@@ -32,10 +50,20 @@ namespace NMEA2000Analyzer
             }
             catch (PcanBasicException)
             {
+                _captureWriter?.Dispose();
+                _captureWriter = null;
                 return (false);
             }
             catch (DllNotFoundException)
             {
+                _captureWriter?.Dispose();
+                _captureWriter = null;
+                return (false);
+            }
+            catch (IOException)
+            {
+                _captureWriter?.Dispose();
+                _captureWriter = null;
                 return (false);
             }
         }
@@ -45,14 +73,20 @@ namespace NMEA2000Analyzer
             {
                 _worker.Stop();
             }
-            catch (PcanBasicException e)
+            catch (PcanBasicException)
             {
+            }
+            finally
+            {
+                _worker.MessageAvailable -= OnMessageAvailable;
+                _captureWriter?.Dispose();
+                _captureWriter = null;
             }
         }
 
         public static List<Nmea2000Record> LoadCapture()
         {
-            return (capture);
+            return capture ?? new List<Nmea2000Record>();
         }
 
         private static void OnMessageAvailable(object? sender, MessageAvailableEventArgs e)
@@ -78,10 +112,10 @@ namespace NMEA2000Analyzer
                 }
 
                 // Format data bytes as a space-separated hex string
-                byte[] data = msg.Data;
+                byte[] data = msg.Data.Take(msg.DLC).ToArray();
                 string dataHex = string.Join(" ", data.Select(b => $"0x{b:X2}"));
 
-                capture.Add(new Nmea2000Record
+                var record = new Nmea2000Record
                 {
                     Timestamp = now.ToString("ss.ffffff"),
                     Source = source.ToString(),
@@ -89,9 +123,23 @@ namespace NMEA2000Analyzer
                     PGN = pgn.ToString(),
                     Priority = priority.ToString(),
                     Data = dataHex,
-                });
+                };
+
+                lock (_captureLock)
+                {
+                    capture?.Add(record);
+                    _captureWriter?.WriteLine(FormatCanDumpRecord(msg.ID, data));
+                }
                 // Debug.WriteLine($"TS: {timestamp}, Src: {source}, Len: {msg.DLC}, PGN: {pgn}");
             }
+        }
+
+        private static string FormatCanDumpRecord(uint canId, byte[] data)
+        {
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0;
+            var timestampText = timestamp.ToString("F3", CultureInfo.InvariantCulture);
+            var dataText = string.Concat(data.Select(b => b.ToString("X2", CultureInfo.InvariantCulture)));
+            return $"({timestampText}) can0 {canId:X8}#{dataText}";
         }
 
     }


### PR DESCRIPTION
## Summary
- add a File -> Save As action for packets already loaded/captured in the app
- export the raw packet list as a candump-style log file
- keep live capture behavior unchanged

## Notes
- this project builds on Windows in GitHub Actions (), so CI should validate the desktop build on the PR
- current export uses the raw  packet list rather than assembled fast-packet view
